### PR TITLE
Mongoose version wildcard in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "release-it": "^8.0.1"
   },
   "peerDependencies": {
-    "mongoose": ""
+    "mongoose": "*"
   }
 }


### PR DESCRIPTION
npm throws a peer dependency warning: `mongoose-type-url@1.0.5 requires a peer of mongoose@ but none is installed.`
I saw that your other package mongoose-type-email uses "*" for mongoose peerdep version, and I figured you may have missed it here. 
And thanks for these useful little packages!